### PR TITLE
Preparing SeL4 support in SDK

### DIFF
--- a/lib/host/include/keystone.h
+++ b/lib/host/include/keystone.h
@@ -22,13 +22,6 @@
 class Keystone;
 typedef void (*OcallFunc)(void*);
 
-struct addr_packed {
-    vaddr_t va;
-    vaddr_t copied;
-    unsigned int eid;
-    unsigned int mode;
-};
-
 class Keystone
 {
 private:

--- a/lib/host/include/keystone_user.h
+++ b/lib/host/include/keystone_user.h
@@ -45,13 +45,17 @@ struct runtime_params_t {
 };
 
 struct keystone_ioctl_create_enclave {
-    __u64 eid;
+  __u64 eid;
 
-    //Min pages required
-    __u64 min_pages;
+  //Min pages required
+  __u64 min_pages;
 
-    // Runtime Parameters
-    struct runtime_params_t params;
+  // virtual addresses
+  __u64 runtime_vaddr;
+  __u64 user_vaddr;
+
+  // Runtime Parameters
+  struct runtime_params_t params;
 };
 
 struct keystone_ioctl_run_enclave {

--- a/lib/host/include/keystone_user.h
+++ b/lib/host/include/keystone_user.h
@@ -27,6 +27,8 @@
   _IOR(KEYSTONE_IOC_MAGIC, 0x08, struct addr_packed)
 #define KEYSTONE_IOC_UTM_INIT \
   _IOR(KEYSTONE_IOC_MAGIC, 0x09, struct keystone_ioctl_create_enclave)
+#define KEYSTONE_IOC_ALLOC_VSPACE \
+  _IOR(KEYSTONE_IOC_MAGIC, 0x0a, struct keystone_ioctl_alloc_vspace)
 
 #define RT_NOEXEC 0
 #define USER_NOEXEC 1
@@ -60,5 +62,17 @@ struct keystone_ioctl_run_enclave {
   __u64 ret;
 };
 
+struct addr_packed {
+  __u64 va;
+  __u64 copied;
+  __u64 eid;
+  __u64 mode;
+};
+
+struct keystone_ioctl_alloc_vspace {
+  __u64 eid;
+  __u64 vaddr;
+  __u64 size;
+};
 
 #endif

--- a/lib/host/include/params.h
+++ b/lib/host/include/params.h
@@ -7,41 +7,40 @@
 
 #include <cstdio>
 
+#define DEFAULT_FREEMEM_SIZE    1024*1024 // 1 MB
 #define DEFAULT_STACK_SIZE      1024*1024 // 1 MB
 #define DEFAULT_UNTRUSTED_PTR   0xffffffffe0000000
 #define DEFAULT_UNTRUSTED_SIZE  8192 // 8 KB
 
 /* parameters for enclave creation */
-struct enclave_params_t {
-  uint64_t runtime_entry;
-  uint64_t runtime_stack_size;
-  uint64_t enclave_entry;
-  uint64_t enclave_stack_size;
-  uint64_t untrusted;
-  uint64_t untrusted_size;
-};
-
 class Params
 {
   public:
     Params() {
-      params.runtime_stack_size = DEFAULT_STACK_SIZE;
-      params.enclave_stack_size = DEFAULT_STACK_SIZE;
-      params.untrusted = DEFAULT_UNTRUSTED_PTR;
-      params.untrusted_size = DEFAULT_UNTRUSTED_SIZE;
+      runtime_stack_size = DEFAULT_STACK_SIZE;
+      enclave_stack_size = DEFAULT_STACK_SIZE;
+      untrusted = DEFAULT_UNTRUSTED_PTR;
+      untrusted_size = DEFAULT_UNTRUSTED_SIZE;
     }
 
     void setEnclaveEntry(uint64_t) { printf("WARN: setEnclaveEntry() is deprecated.\n"); }
-    void setRuntimeStack(uint64_t size) { params.runtime_stack_size = size; }
-    void setEnclaveStack(uint64_t size) { params.enclave_stack_size = size; }
-    void setUntrustedMem(uint64_t ptr, uint64_t size) { params.untrusted = ptr; params.untrusted_size = size; }
-    uint64_t getRuntimeStack() { return params.runtime_stack_size; }
-    uint64_t getEnclaveStack() { return params.enclave_stack_size; }
-    uint64_t getUntrustedMem() { return params.untrusted; }
-    uint64_t getUntrustedSize() { return params.untrusted_size; }
-    struct enclave_params_t getParams() { return params; }
+    void setRuntimeStack(uint64_t size) { runtime_stack_size = size; }
+    void setEnclaveStack(uint64_t size) { enclave_stack_size = size; }
+    void setUntrustedMem(uint64_t ptr, uint64_t size) { untrusted = ptr; untrusted_size = size; }
+    void setFreeMemSize(uint64_t size) { freemem_size = size; }
+    uint64_t getRuntimeStack() { return runtime_stack_size; }
+    uint64_t getEnclaveStack() { return enclave_stack_size; }
+    uint64_t getUntrustedMem() { return untrusted; }
+    uint64_t getUntrustedSize() { return untrusted_size; }
+    uint64_t getFreeMemSize() { return freemem_size; }
   private:
-    struct enclave_params_t params;
+    uint64_t runtime_entry;
+    uint64_t runtime_stack_size;
+    uint64_t enclave_entry;
+    uint64_t enclave_stack_size;
+    uint64_t untrusted;
+    uint64_t untrusted_size;
+    uint64_t freemem_size;
 };
 
 #endif

--- a/lib/host/src/keystone.cpp
+++ b/lib/host/src/keystone.cpp
@@ -111,6 +111,17 @@ keystone_status_t Keystone::loadELF(ELFFile* elf)
   static char nullpage[PAGE_SIZE] = {0,};
   unsigned int mode = elf->getPageMode();
 
+  /* reserve virtual address space for linear mapping */
+  struct keystone_ioctl_alloc_vspace vspace;
+  vspace.eid = eid;
+  vspace.vaddr = elf->getMinVaddr();
+  vspace.size = elf->getTotalMemorySize();
+  if(ioctl(fd, KEYSTONE_IOC_ALLOC_VSPACE, &vspace)) {
+    PERROR("failed to reserve vspace - ioctl() failed");
+    destroy();
+    return KEYSTONE_ERROR;
+  }
+
   for (unsigned int i = 0; i < elf->getNumProgramHeaders(); i++) {
 
     if (elf->getProgramHeaderType(i) != PT_LOAD) {

--- a/lib/host/src/keystone.cpp
+++ b/lib/host/src/keystone.cpp
@@ -218,8 +218,13 @@ keystone_status_t Keystone::init(const char *eapppath, const char *runtimepath, 
   enclp.params.untrusted_ptr = (unsigned long) params.getUntrustedMem();
   enclp.params.untrusted_size = (unsigned long) params.getUntrustedSize();
 
-  enclp.min_pages = calculate_required_pages(enclaveFile->getTotalMemorySize(), params.getEnclaveStack(),
+  // FIXME: this will be deprecated with complete freemem support.
+  // We just add freemem size for now.
+  enclp.min_pages = ROUND_UP(params.getFreeMemSize(), PAGE_BITS)/PAGE_SIZE;
+  enclp.min_pages += calculate_required_pages(enclaveFile->getTotalMemorySize(), params.getEnclaveStack(),
       runtimeFile->getTotalMemorySize(), params.getRuntimeStack());
+  enclp.runtime_vaddr = (unsigned long) runtimeFile->getMinVaddr();
+  enclp.user_vaddr = (unsigned long) enclaveFile->getMinVaddr();
 
   runtime_stk_sz = params.getRuntimeStack();
   enclave_stk_sz = params.getEnclaveStack();


### PR DESCRIPTION
Two things that have changed:
(1) The user linearize the physical address by using a new ioctl (VSPACE_ALLOC)
(2) The user passes more parameters (e.g., freemem size, virtual addresses) that is needed to create and finalize the enclave.

@alexthomas1 `addr_packed` structure has been moved to `keystone_user.h`,
and also a few lines have been added to `Keystone::init`. Beware of conflicts!