### PR TITLE
A few changes with freemem support

### DIFF
--- a/lib/host/include/params.h
+++ b/lib/host/include/params.h
@@ -9,7 +9,7 @@
 
 #define DEFAULT_FREEMEM_SIZE    1024*1024 // 1 MB
 #define DEFAULT_STACK_SIZE      1024*1024 // 1 MB
-#define DEFAULT_UNTRUSTED_PTR   0xffffffffe0000000
+#define DEFAULT_UNTRUSTED_PTR   0xffffffff80000000
 #define DEFAULT_UNTRUSTED_SIZE  8192 // 8 KB
 
 /* parameters for enclave creation */

--- a/lib/host/include/params.h
+++ b/lib/host/include/params.h
@@ -17,7 +17,6 @@ class Params
 {
   public:
     Params() {
-      runtime_stack_size = DEFAULT_STACK_SIZE;
       enclave_stack_size = DEFAULT_STACK_SIZE;
       untrusted = DEFAULT_UNTRUSTED_PTR;
       untrusted_size = DEFAULT_UNTRUSTED_SIZE;
@@ -25,18 +24,15 @@ class Params
     }
 
     void setEnclaveEntry(uint64_t) { printf("WARN: setEnclaveEntry() is deprecated.\n"); }
-    void setRuntimeStack(uint64_t size) { runtime_stack_size = size; }
     void setEnclaveStack(uint64_t size) { enclave_stack_size = size; }
     void setUntrustedMem(uint64_t ptr, uint64_t size) { untrusted = ptr; untrusted_size = size; }
     void setFreeMemSize(uint64_t size) { freemem_size = size; }
-    uint64_t getRuntimeStack() { return runtime_stack_size; }
     uint64_t getEnclaveStack() { return enclave_stack_size; }
     uint64_t getUntrustedMem() { return untrusted; }
     uint64_t getUntrustedSize() { return untrusted_size; }
     uint64_t getFreeMemSize() { return freemem_size; }
   private:
     uint64_t runtime_entry;
-    uint64_t runtime_stack_size;
     uint64_t enclave_entry;
     uint64_t enclave_stack_size;
     uint64_t untrusted;


### PR DESCRIPTION
A few changes have been made to support freemem in the runtime.
(1) Runtime Stack is a part of the runtime ELF so that we don't need to remap that when boot time
(2) Shared buffer address has been changed to make it easy to just copy old page table entries to the new page table.