### PR TITLE
Adds sealing feature similar to Intel SGX

### DIFF
--- a/examples/tests/test-runner.cpp
+++ b/examples/tests/test-runner.cpp
@@ -122,7 +122,6 @@ int main(int argc, char** argv)
   }
 
   enclave.init(eapp_file, rt_file , params);
-  enclave.measure(eapp_file, rt_file , params);
 
   if( self_timing ){
     asm volatile ("rdcycle %0" : "=r" (cycles2));

--- a/lib/app/include/sealing.h
+++ b/lib/app/include/sealing.h
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (C) 2020 Fraunhofer AISEC
+ *  Authors: Benedikt Kopf <benedikt.kopf@aisec.fraunhofer.de>
+ *           Lukas Auer <lukas.auer@aisec.fraunhofer.de>
+ *           Mathias Morbitzer <mathias.morbitzer@aisec.fraunhofer.de>
+ *
+ *  sealing.h
+ *
+ *  Provides the necessary definitions to derive a seal key
+ *
+ *  All Rights Reserved. See LICENSE for license details.
+ */
+
+#ifndef SEALING_H
+#define SEALING_H
+
+#define SEALING_KEY_SIZE 128
+#define SIGNATURE_SIZE 64
+
+/* sealing key structure */
+struct sealing_key {
+  uint8_t key[SEALING_KEY_SIZE];
+  uint8_t signature[SIGNATURE_SIZE];
+};
+
+#endif /* SEALING_H */

--- a/lib/app/include/syscall.h
+++ b/lib/app/include/syscall.h
@@ -7,11 +7,13 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include "sealing.h"
 /* TODO We should be syncing these more explictly with the runtime
    defs */
 #define SYSCALL_OCALL 1001
 #define SYSCALL_SHAREDCOPY  1002
 #define SYSCALL_ATTEST_ENCLAVE  1003
+#define SYSCALL_GET_SEALING_KEY 1004
 #define SYSCALL_EXIT  1101
 
 #define SYSCALL(which, arg0, arg1, arg2, arg3, arg4) ( {	\
@@ -32,6 +34,7 @@
 #define SYSCALL_1(which, arg0) SYSCALL(which, arg0, 0, 0, 0, 0)
 #define SYSCALL_2(which, arg0, arg1) SYSCALL(which, arg0, arg1, 0, 0, 0)
 #define SYSCALL_3(which, arg0, arg1, arg2) SYSCALL(which, arg0, arg1, arg2, 0, 0)
+#define SYSCALL_4(which, arg0, arg1, arg2, arg3) SYSCALL(which, arg0, arg1, arg2, arg3, 0)
 #define SYSCALL_5(which, arg0, arg1, arg2, arg3, arg4) SYSCALL(which, arg0, arg1, arg2, arg3, arg4)
 
 int copy_from_shared(void* dst,
@@ -42,5 +45,9 @@ int ocall(unsigned long call_id,
 	  void* return_buffer, size_t return_len);
 uintptr_t untrusted_mmap();
 int attest_enclave(void* report, void* data, size_t size);
+
+int get_sealing_key(struct sealing_key *sealing_key_struct,
+                    size_t sealing_key_struct_size,
+                    void *key_ident, size_t key_ident_size);
 
 #endif /* syscall.h */

--- a/lib/app/src/syscall.c
+++ b/lib/app/src/syscall.c
@@ -21,3 +21,13 @@ int attest_enclave(void* report, void* data, size_t size)
 {
   return SYSCALL_3(SYSCALL_ATTEST_ENCLAVE, report, data, size);
 }
+
+/* returns sealing key */
+int get_sealing_key(struct sealing_key *sealing_key_struct,
+                    size_t sealing_key_struct_size,
+                    void *key_ident, size_t key_ident_size)
+{
+  return SYSCALL_4(SYSCALL_GET_SEALING_KEY, sealing_key_struct,
+                   sealing_key_struct_size,
+                   key_ident, key_ident_size);
+}

--- a/lib/host/include/keystone.h
+++ b/lib/host/include/keystone.h
@@ -71,7 +71,6 @@ public:
   keystone_status_t registerOcallDispatch(OcallFunc func);
   keystone_status_t init(const char* filepath, const char* runtime, Params parameters);
   keystone_status_t init(const char *eapppath, const char *runtimepath, Params _params, uintptr_t alternate_phys_addr);
-  keystone_status_t measure(const char* filepath, const char* runtime, Params parameters);
   keystone_status_t destroy();
   keystone_status_t run();
 


### PR DESCRIPTION
This change adds the necessary definitions and functions in the SDK, to support the sealing feature of the security monitor. With that feature the enclave user is able to derive a sealing key bound to the CPU, the identity of the security monitor and the identity of the enclave.