### PR TITLE
[examples] Allow examples to be built independently

### DIFF
--- a/.post-install/CMakeLists.txt
+++ b/.post-install/CMakeLists.txt
@@ -1,3 +1,4 @@
 install(CODE "message(\"\n * Keystone SDK has been installed at ${out_dir}\")")
-install(CODE "message(\" * Run `export KEYSTONE_SDK_DIR=${out_dir}`\")")
 install(CODE "message(\" * Use `make uninstall` to uninstall\")")
+install(CODE "message(\" * Please add the following to your shell's start-up file (e.g., $HOME/.bashrc)\")")
+install(CODE "message(\"     export KEYSTONE_SDK_DIR=${out_dir}\")")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,14 +17,16 @@ set(src_dir      ${CMAKE_CURRENT_LIST_DIR})
 set(scripts_dir  ${src_dir}/scripts)
 set(cross_compile riscv${BITS}-unknown-linux-gnu-)
 
-
-if (OUTPUT_DIR)
-  if (NOT IS_ABSOLUTE ${OUTPUT_DIR})
-    message(FATAL_ERROR "OUTPUT_DIR needs to be absolute path")
+if (DEFINED ENV{KEYSTONE_SDK_DIR})
+  set(KEYSTONE_SDK_DIR $ENV{KEYSTONE_SDK_DIR})
+  if (NOT IS_ABSOLUTE ${KEYSTONE_SDK_DIR})
+    message(FATAL_ERROR "KEYSTONE_SDK_DIR needs to be absolute path")
   endif()
-  get_filename_component(OUTPUT_DIR ${OUTPUT_DIR} ABSOLUTE)
-  set(out_dir    ${OUTPUT_DIR})
+  get_filename_component(KEYSTONE_SDK_DIR ${KEYSTONE_SDK_DIR} ABSOLUTE)
+  set(out_dir    ${KEYSTONE_SDK_DIR})
 else()
+  message(FATAL_ERROR " * Set KEYSTONE_SDK_DIR to the path you want to install the SDK.\n"
+    " * Try `export KEYSTONE_SDK_DIR=<path/to/SDK>`")
   set(out_dir    ${CMAKE_BINARY_DIR})
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(macros.cmake)
+
 cmake_minimum_required(VERSION 3.10)
 enable_language(C CXX ASM)
 #-------------------------------------------------------------------------------
@@ -15,7 +17,6 @@ endif()
 set(prog_name    keystone-sdk)
 set(src_dir      ${CMAKE_CURRENT_LIST_DIR})
 set(scripts_dir  ${src_dir}/scripts)
-set(cross_compile riscv${BITS}-unknown-linux-gnu-)
 
 if (DEFINED ENV{KEYSTONE_SDK_DIR})
   set(KEYSTONE_SDK_DIR $ENV{KEYSTONE_SDK_DIR})
@@ -40,7 +41,6 @@ message(" *** Install path: ${out_dir}")
 # Program and flags
 #-------------------------------------------------------------------------------
 
-include(macros.cmake)
 
 if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE    "Debug")
@@ -55,45 +55,7 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
     set(CMAKE_C_FLAGS ${CMAKE_C_FLAGS} -g)
 endif()
 
-execute_process(
-    COMMAND which ${cross_compile}gcc
-    OUTPUT_VARIABLE CROSSCOMPILE
-    RESULT_VARIABLE ERROR)
-
-if (NOT "${ERROR}" STREQUAL 0)
-    message(FATAL_ERROR "RISCV Toochain is not found")
-endif()
-
-string(STRIP ${CROSSCOMPILE} CROSSCOMPILE)
-string(REPLACE "gcc" "" CROSSCOMPILE ${CROSSCOMPILE})
-
-message(STATUS "Tagret tripplet: ${CROSSCOMPILE}")
-
-set(CC              ${CROSSCOMPILE}gcc)
-set(CXX             ${CROSSCOMPILE}g++)
-set(LD              ${CROSSCOMPILE}ld)
-set(AR              ${CROSSCOMPILE}ar)
-set(OBJCOPY         ${CROSSCOMPILE}objcopy)
-set(OBJDUMP         ${CROSSCOMPILE}objdump)
-set(CFLAGS          "-Wall -Werror")
-
-global_set(CMAKE_C_COMPILER        ${CC}${EXT})
-global_set(CMAKE_ASM_COMPILER        ${CC}${EXT})
-global_set(CMAKE_CXX_COMPILER      ${CXX}${EXT})
-global_set(CMAKE_LINKER            ${LD}${EXT})
-global_set(CMAKE_AR                ${AR}${EXT})
-global_set(CMAKE_OBJCOPY           ${OBJCOPY}${EXT})
-global_set(CMAKE_OBJDUMP           ${OBJDUMP}${EXT})
-global_set(CMAKE_C_FLAGS           ${CMAKE_C_FLAGS} ${CFLAGS})
-
-check_compiler(${CMAKE_C_COMPILER})
-check_compiler(${CMAKE_CXX_COMPILER})
-
-global_set(CMAKE_C_COMPILER_WORKS      1)
-global_set(CMAKE_CXX_COMPILER_WORKS    1)
-
-global_set(CMAKE_SYSTEM_NAME    "Linux")
-
+use_riscv_toolchain(${BITS})
 ################################################################################
 # BUILD PROJECTS
 ################################################################################

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ If not specified, the install directory will be the same as the build directory.
 
 ```bash
 mkdir build
-cmake .. -DOUTPUT_DIR=<install directory>
+cd build
+export KEYSTONE_SDK_DIR=<install_directory>
+cmake ..
 make
 make install
 ```
@@ -16,7 +18,7 @@ To uninstall,
 make uninstall
 ```
 
-Run the following command to complete the installation. Ideally, you may need to add it to your shell rcfile (e.g., .bashrc)
+Ideally, you may need to add the following to your shell rcfile (e.g., .bashrc)
 
 ```bash
 export KEYSTONE_SDK_DIR=<install directory>

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,4 @@
+include(../macros.cmake)
 include(ExternalProject)
 find_package(Git REQUIRED)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,18 @@
+enable_language(C CXX ASM)
+
 include(../macros.cmake)
 include(ExternalProject)
 find_package(Git REQUIRED)
+
+if(RISCV32)
+  message(STATUS "riscv32")
+  set(BITS 32)
+else()
+  message(STATUS "riscv64")
+  set(BITS 64)
+endif()
+
+use_riscv_toolchain(${BITS})
 
 # check if SDK has been built and KEYSTONE_SDK_DIR environment variable exists
 if (NOT DEFINED ENV{KEYSTONE_SDK_DIR})

--- a/macros.cmake
+++ b/macros.cmake
@@ -120,7 +120,7 @@ macro(add_keystone_package target_name package_name package_script) # files are 
 
   add_custom_target(${target_name} DEPENDS ${pkg_files}
     COMMAND
-      ${MAKESELF} ${pkg_dir} ${package_name} "Keystone Enclave Package" "${package_script}"
+      ${MAKESELF} --noprogress ${pkg_dir} ${package_name} "Keystone Enclave Package" "${package_script}"
     VERBATIM
     )
 

--- a/macros.cmake
+++ b/macros.cmake
@@ -3,29 +3,72 @@ macro(global_set Name Value)
     set(${Name} "${Value}" CACHE STRING "NoDesc" FORCE)
 endmacro()
 
-macro(check_compiler target)
-    message(STATUS "Check for working C compiler: ${target}")
-    execute_process(
-        COMMAND ${target} -print-file-name=crt.o
-        OUTPUT_FILE OUTPUT
-        RESULT_VARIABLE ERROR)
+macro(use_riscv_toolchain bits)
+  set(cross_compile riscv${bits}-unknown-linux-gnu-)
+  execute_process(
+    COMMAND which ${cross_compile}gcc
+    OUTPUT_VARIABLE CROSSCOMPILE
+    RESULT_VARIABLE ERROR)
 
-    if ("${ERROR}" STREQUAL 0)
-        message(STATUS "Check for working C compiler: ${target} -- works")
-    else()
-        message(FATAL_ERROR "Check for working C compiler: ${target} -- not working")
-    endif()
+  if (NOT "${ERROR}" STREQUAL 0)
+    message(FATAL_ERROR "RISCV Toochain is not found")
+  endif()
+
+  string(STRIP ${CROSSCOMPILE} CROSSCOMPILE)
+  string(REPLACE "gcc" "" CROSSCOMPILE ${CROSSCOMPILE})
+
+  message(STATUS "Tagret tripplet: ${CROSSCOMPILE}")
+
+  set(CC              ${CROSSCOMPILE}gcc)
+  set(CXX             ${CROSSCOMPILE}g++)
+  set(LD              ${CROSSCOMPILE}ld)
+  set(AR              ${CROSSCOMPILE}ar)
+  set(OBJCOPY         ${CROSSCOMPILE}objcopy)
+  set(OBJDUMP         ${CROSSCOMPILE}objdump)
+  set(CFLAGS          "-Wall -Werror")
+
+  global_set(CMAKE_C_COMPILER        ${CC}${EXT})
+  global_set(CMAKE_ASM_COMPILER        ${CC}${EXT})
+  global_set(CMAKE_CXX_COMPILER      ${CXX}${EXT})
+  global_set(CMAKE_LINKER            ${LD}${EXT})
+  global_set(CMAKE_AR                ${AR}${EXT})
+  global_set(CMAKE_OBJCOPY           ${OBJCOPY}${EXT})
+  global_set(CMAKE_OBJDUMP           ${OBJDUMP}${EXT})
+  global_set(CMAKE_C_FLAGS           ${CMAKE_C_FLAGS} ${CFLAGS})
+
+  check_compiler(${CMAKE_C_COMPILER})
+  check_compiler(${CMAKE_CXX_COMPILER})
+
+  global_set(CMAKE_C_COMPILER_WORKS      1)
+  global_set(CMAKE_CXX_COMPILER_WORKS    1)
+
+  global_set(CMAKE_SYSTEM_NAME    "Linux")
+
+endmacro()
+
+macro(check_compiler target)
+  message(STATUS "Check for working C compiler: ${target}")
+  execute_process(
+    COMMAND ${target} -print-file-name=crt.o
+    OUTPUT_FILE OUTPUT
+    RESULT_VARIABLE ERROR)
+
+  if ("${ERROR}" STREQUAL 0)
+    message(STATUS "Check for working C compiler: ${target} -- works")
+  else()
+    message(FATAL_ERROR "Check for working C compiler: ${target} -- not working")
+  endif()
 endmacro()
 
 macro(subdirs_list OUT_VARIABLE DIRWORK)
-    file(GLOB children RELATIVE ${DIRWORK} ${DIRWORK}/*)
-    set(_subdirs    "")
-    foreach(child ${children})
-        if (IS_DIRECTORY ${DIRWORK}/${child})
-            list(APPEND _subdirs  ${child})
-        endif()
-    endforeach()
-    set(${OUT_VARIABLE} ${_subdirs})
+  file(GLOB children RELATIVE ${DIRWORK} ${DIRWORK}/*)
+  set(_subdirs    "")
+  foreach(child ${children})
+    if (IS_DIRECTORY ${DIRWORK}/${child})
+      list(APPEND _subdirs  ${child})
+    endif()
+  endforeach()
+  set(${OUT_VARIABLE} ${_subdirs})
 endmacro()
 
 macro(add_files FILE_LIST DIRWORK)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,8 +12,7 @@ foreach(module ${enabled_libmodules})
     add_subdirectory(${module})
 endforeach()
 
-
-install(DIRECTORY ${COMMON_INCLUDE_DIRS}
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/common
   DESTINATION ${out_dir}/include)
 
 


### PR DESCRIPTION
Detach examples/CMakeLists.txt from the main repo so that one can independently build examples if SDK is installed and KEYSTONE_SDK_DIR is set.
This involves a few changes on multiple CMakeLists.txt.
