### PR TITLE
sdk: force musl toolchain compilation for hello

### DIFF
--- a/examples/hello/CMakeLists.txt
+++ b/examples/hello/CMakeLists.txt
@@ -13,8 +13,10 @@ endif()
 
 # eapp
 
-add_executable(${eapp_bin} ${eapp_src})
-target_link_libraries(${eapp_bin} "-static")
+add_custom_command(OUTPUT ${eapp_bin}
+  COMMAND
+  riscv64-unknown-linux-musl-gcc -static -o ${CMAKE_CURRENT_BINARY_DIR}/${eapp_bin}
+${CMAKE_CURRENT_SOURCE_DIR}/${eapp_src})
 
 # host
 


### PR DESCRIPTION
Since CMake doesn't support multiple toolchains, we have to add a custom command that forces the use of the musl toolchain for libc-based executables