### PR TITLE
Implements a full attestation example.

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -39,4 +39,5 @@ add_custom_target("examples")
 # add all examples below
 add_subdirectory(hello)
 add_subdirectory(hello-native)
+add_subdirectory(attestation)
 add_subdirectory(tests)

--- a/examples/attestation/CMakeLists.txt
+++ b/examples/attestation/CMakeLists.txt
@@ -1,0 +1,54 @@
+set(eapp_bin attestor)
+set(eapp_src eapp/attestor.c)
+set(host_bin attestor-runner)
+set(host_src host/attestor-runner.cpp host/host.cpp host/verifier.cpp)
+set(package_name "attestor.ke")
+set(package_script "./attestor-runner attestor eyrie-rt --sm-bin fw_payload.bin")
+
+if(RISCV32)
+  set(eyrie_plugins "freemem rv32")
+else()
+  set(eyrie_plugins "freemem")
+endif()
+
+# eapp
+
+add_executable(${eapp_bin} ${eapp_src})
+target_link_libraries(${eapp_bin} "-nostdlib -static" ${KEYSTONE_LIB_EAPP} ${KEYSTONE_LIB_EDGE})
+target_include_directories(${eapp_bin}
+  PUBLIC ${KEYSTONE_SDK_DIR}/include/app
+  PUBLIC ${KEYSTONE_SDK_DIR}/include/edge)
+
+# host
+
+add_executable(${host_bin} ${host_src})
+target_link_libraries(${host_bin}
+  ${KEYSTONE_LIB_HOST} ${KEYSTONE_LIB_EDGE} ${KEYSTONE_LIB_VERIFIER})
+set_target_properties(${host_bin}
+  PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED YES CXX_EXTENSIONS NO
+  )
+target_include_directories(${host_bin}
+  PUBLIC ${KEYSTONE_SDK_DIR}/include/common
+  PUBLIC ${KEYSTONE_SDK_DIR}/include/host
+  PUBLIC ${KEYSTONE_SDK_DIR}/include/edge
+  PUBLIC ${KEYSTONE_SDK_DIR}/include/verifier)
+
+# add target for Eyrie runtime (see keystone.cmake)
+
+set(eyrie_files_to_copy .options_log eyrie-rt)
+add_eyrie_runtime(${eapp_bin}-eyrie
+  "v1.0.0"
+  ${eyrie_plugins}
+  ${eyrie_files_to_copy})
+
+# add target for packaging (see keystone.cmake)
+
+add_keystone_package(${eapp_bin}-package
+  ${package_name}
+  ${package_script}
+  ${eyrie_files_to_copy} ${eapp_bin} ${host_bin} ${fw_bin})
+
+add_dependencies(${eapp_bin}-package ${eapp_bin}-eyrie)
+
+# add package to the top-level target
+add_dependencies(examples ${eapp_bin}-package)

--- a/examples/attestation/eapp/attestor.c
+++ b/examples/attestation/eapp/attestor.c
@@ -1,0 +1,35 @@
+//******************************************************************************
+// Copyright (c) 2018, The Regents of the University of California (Regents).
+// All Rights Reserved. See LICENSE for license details.
+//------------------------------------------------------------------------------
+#include "app/eapp_utils.h"
+#include "app/syscall.h"
+#include "edge/edge_common.h"
+
+#define OCALL_PRINT_BUFFER 1
+#define OCALL_PRINT_VALUE 2
+#define OCALL_COPY_REPORT 3
+#define OCALL_GET_STRING 4
+
+int
+main() {
+  struct edge_data retdata;
+  ocall(OCALL_GET_STRING, NULL, 0, &retdata, sizeof(struct edge_data));
+
+  for (unsigned long i = 1; i <= 10000; i++) {
+    if (i % 5000 == 0) {
+      ocall(OCALL_PRINT_VALUE, &i, sizeof(unsigned long), 0, 0);
+    }
+  }
+
+  char nonce[2048];
+  if (retdata.size > 2048) retdata.size = 2048;
+  copy_from_shared(nonce, retdata.offset, retdata.size);
+
+  char buffer[2048];
+  attest_enclave((void*)buffer, nonce, retdata.size);
+
+  ocall(OCALL_COPY_REPORT, buffer, 2048, 0, 0);
+
+  EAPP_RETURN(0);
+}

--- a/examples/attestation/host/attestor-runner.cpp
+++ b/examples/attestation/host/attestor-runner.cpp
@@ -1,0 +1,84 @@
+//******************************************************************************
+// Copyright (c) 2018, The Regents of the University of California (Regents).
+// All Rights Reserved. See LICENSE for license details.
+//------------------------------------------------------------------------------
+#include <getopt.h>
+#include <stdlib.h>
+
+#include <cerrno>
+#include <cstdio>
+#include <functional>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+#include "host/keystone.h"
+#include "verifier/report.h"
+
+#include "verifier.h"
+
+int
+main(int argc, char** argv) {
+  if (argc < 3 || argc > 8) {
+    printf(
+        "Usage: %s <eapp> <runtime> [--utm-size SIZE(K)] [--freemem-size "
+        "SIZE(K)] [--utm-ptr 0xPTR] [--sm-bin SM_BIN_PATH]\n",
+        argv[0]);
+    return 0;
+  }
+
+  int self_timing = 0;
+  int load_only   = 0;
+
+  size_t untrusted_size = 2 * 1024 * 1024;
+  size_t freemem_size   = 48 * 1024 * 1024;
+  uintptr_t utm_ptr     = (uintptr_t)DEFAULT_UNTRUSTED_PTR;
+  bool retval_exist     = false;
+  unsigned long retval  = 0;
+
+  static struct option long_options[] = {
+      {"utm-size", required_argument, 0, 'u'},
+      {"utm-ptr", required_argument, 0, 'p'},
+      {"freemem-size", required_argument, 0, 'f'},
+      {"sm-bin", required_argument, 0, 's'},
+      {0, 0, 0, 0}};
+
+  char* eapp_file   = argv[1];
+  char* rt_file     = argv[2];
+  char* sm_bin_file = NULL;
+
+  int c;
+  int opt_index = 3;
+  while (1) {
+    c = getopt_long(argc, argv, "u:p:f:s:", long_options, &opt_index);
+
+    if (c == -1) break;
+
+    switch (c) {
+      case 0:
+        break;
+      case 'u':
+        untrusted_size = atoi(optarg) * 1024;
+        break;
+      case 'p':
+        utm_ptr = strtoll(optarg, NULL, 16);
+        break;
+      case 'f':
+        freemem_size = atoi(optarg) * 1024;
+        break;
+      case 's':
+        sm_bin_file = optarg;
+        break;
+    }
+  }
+
+  Keystone::Params params;
+
+  params.setFreeMemSize(freemem_size);
+  params.setUntrustedMem(utm_ptr, untrusted_size);
+
+  Verifier verifier{params, eapp_file, rt_file, sm_bin_file};
+  verifier.run();
+
+  return 0;
+}

--- a/examples/attestation/host/host.cpp
+++ b/examples/attestation/host/host.cpp
@@ -1,0 +1,253 @@
+//******************************************************************************
+// Copyright (c) 2018, The Regents of the University of California (Regents).
+// All Rights Reserved. See LICENSE for license details.
+//------------------------------------------------------------------------------
+#include "host.h"
+
+#include <getopt.h>
+#include <stdlib.h>
+
+#include <cerrno>
+#include <cstdio>
+#include <functional>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+#include "edge/edge_common.h"
+#include "host/keystone.h"
+#include "verifier/report.h"
+
+#define OCALL_PRINT_BUFFER 1
+#define OCALL_PRINT_VALUE 2
+#define OCALL_COPY_REPORT 3
+#define OCALL_GET_STRING 4
+
+void
+SharedBuffer::set_ok() {
+  edge_call_->return_data.call_status = CALL_STATUS_OK;
+}
+
+void
+SharedBuffer::set_bad_offset() {
+  edge_call_->return_data.call_status = CALL_STATUS_BAD_OFFSET;
+}
+void
+SharedBuffer::set_bad_ptr() {
+  edge_call_->return_data.call_status = CALL_STATUS_BAD_PTR;
+}
+
+int
+SharedBuffer::get_ptr_from_offset(edge_data_offset offset, uintptr_t* ptr) {
+  /* Validate that _shared_start+offset is sane */
+  if (offset > UINTPTR_MAX - buffer_ || offset > buffer_len_) {
+    return -1;
+  }
+
+  /* ptr looks valid, create it */
+  *ptr = buffer_ + offset;
+  return 0;
+}
+
+int
+SharedBuffer::args_ptr(uintptr_t* ptr, size_t* size) {
+  *size = edge_call_->call_arg_size;
+  return get_ptr_from_offset(edge_call_->call_arg_offset, ptr);
+}
+
+std::optional<std::pair<uintptr_t, size_t>>
+SharedBuffer::get_call_args_ptr_or_set_bad_offset() {
+  uintptr_t call_args;
+  size_t arg_len;
+  if (args_ptr(&call_args, &arg_len) != 0) {
+    set_bad_offset();
+    return std::nullopt;
+  }
+  return std::pair{call_args, arg_len};
+}
+
+std::optional<char*>
+SharedBuffer::get_c_string_or_set_bad_offset() {
+  auto v = get_call_args_ptr_or_set_bad_offset();
+  return v.has_value() ? std::optional{(char*)v.value().first} : std::nullopt;
+}
+
+std::optional<unsigned long>
+SharedBuffer::get_unsigned_long_or_set_bad_offset() {
+  auto v = get_call_args_ptr_or_set_bad_offset();
+  return v.has_value() ? std::optional{*(unsigned long*)v.value().first}
+                       : std::nullopt;
+}
+
+std::optional<Report>
+SharedBuffer::get_report_or_set_bad_offset() {
+  auto v = get_call_args_ptr_or_set_bad_offset();
+  if (!v.has_value()) return std::nullopt;
+  Report ret;
+  ret.fromBytes((byte*)v.value().first);
+  return ret;
+}
+
+uintptr_t
+SharedBuffer::data_ptr() {
+  return (uintptr_t)edge_call_ + sizeof(struct edge_call);
+}
+
+int
+SharedBuffer::validate_ptr(uintptr_t ptr) {
+  /* Validate that ptr starts in range */
+  if (ptr > buffer_ + buffer_len_ || ptr < buffer_) {
+    return 1;
+  }
+  return 0;
+}
+
+int
+SharedBuffer::get_offset_from_ptr(uintptr_t ptr, edge_data_offset* offset) {
+  int valid = validate_ptr(ptr);
+  if (valid != 0) return valid;
+
+  /* ptr looks valid, create it */
+  *offset = ptr - buffer_;
+  return 0;
+}
+
+int
+SharedBuffer::setup_ret(void* ptr, size_t size) {
+  edge_call_->return_data.call_ret_size = size;
+  return get_offset_from_ptr(
+      (uintptr_t)ptr, &edge_call_->return_data.call_ret_offset);
+}
+
+void
+SharedBuffer::setup_ret_or_bad_ptr(unsigned long ret_val) {
+  // Assuming we are done with the data section for args, use as
+  // return region.
+  //
+  // TODO safety check?
+  uintptr_t data_section = data_ptr();
+
+  memcpy((void*)data_section, &ret_val, sizeof(unsigned long));
+
+  if (setup_ret((void*)data_section, sizeof(unsigned long))) {
+    set_bad_ptr();
+  } else {
+    set_ok();
+  }
+}
+
+int
+SharedBuffer::setup_wrapped_ret(void* ptr, size_t size) {
+  struct edge_data data_wrapper;
+  data_wrapper.size = size;
+  get_offset_from_ptr(
+      buffer_ + sizeof(struct edge_call) + sizeof(struct edge_data),
+      &data_wrapper.offset);
+
+  memcpy(
+      (void*)(buffer_ + sizeof(struct edge_call) + sizeof(struct edge_data)),
+      ptr, size);
+
+  memcpy(
+      (void*)(buffer_ + sizeof(struct edge_call)), &data_wrapper,
+      sizeof(struct edge_data));
+
+  edge_call_->return_data.call_ret_size = sizeof(struct edge_data);
+  return get_offset_from_ptr(
+      buffer_ + sizeof(struct edge_call),
+      &edge_call_->return_data.call_ret_offset);
+}
+
+void
+SharedBuffer::setup_wrapped_ret_or_bad_ptr(const std::string& ret_val) {
+  if (setup_wrapped_ret((void*)ret_val.c_str(), ret_val.length() + 1)) {
+    set_bad_ptr();
+  } else {
+    set_ok();
+  }
+  return;
+}
+
+void
+Host::print_buffer_wrapper(RunData& run_data) {
+  SharedBuffer& shared_buffer = run_data.shared_buffer;
+
+  auto t = shared_buffer.get_c_string_or_set_bad_offset();
+  if (t.has_value()) {
+    printf("Enclave said: %s", t.value());
+    auto ret_val = strlen(t.value());
+    shared_buffer.setup_ret_or_bad_ptr(ret_val);
+  }
+}
+
+void
+Host::print_value_wrapper(RunData& run_data) {
+  SharedBuffer& shared_buffer = run_data.shared_buffer;
+
+  auto t = shared_buffer.get_unsigned_long_or_set_bad_offset();
+  if (t.has_value()) {
+    printf("Enclave said value: %u\n", t.value());
+    shared_buffer.set_ok();
+  }
+  return;
+}
+
+void
+Host::copy_report_wrapper(RunData& run_data) {
+  SharedBuffer& shared_buffer = run_data.shared_buffer;
+
+  auto t = shared_buffer.get_report_or_set_bad_offset();
+  if (t.has_value()) {
+    run_data.report = std::make_unique<Report>(std::move(t.value()));
+    shared_buffer.set_ok();
+  }
+  return;
+}
+
+void
+Host::get_host_string_wrapper(RunData& run_data) {
+  SharedBuffer& shared_buffer = run_data.shared_buffer;
+
+  shared_buffer.setup_wrapped_ret_or_bad_ptr(run_data.nonce);
+  return;
+}
+
+void
+Host::dispatch_ocall(RunData& run_data) {
+  struct edge_call* edge_call = (struct edge_call*)run_data.shared_buffer.ptr();
+  switch (edge_call->call_id) {
+    case OCALL_PRINT_BUFFER:
+      print_buffer_wrapper(run_data);
+      break;
+    case OCALL_PRINT_VALUE:
+      print_value_wrapper(run_data);
+      break;
+    case OCALL_COPY_REPORT:
+      copy_report_wrapper(run_data);
+      break;
+    case OCALL_GET_STRING:
+      get_host_string_wrapper(run_data);
+      break;
+  }
+  return;
+}
+
+Report
+Host::run(const std::string& nonce) {
+  Keystone::Enclave enclave;
+  enclave.init(eapp_file_.c_str(), rt_file_.c_str(), params_);
+
+  RunData run_data{
+      SharedBuffer{enclave.getSharedBuffer(), enclave.getSharedBufferSize()},
+      nonce, nullptr};
+
+  enclave.registerOcallDispatch([&run_data](void* buffer) {
+    assert(buffer == (void*)run_data.shared_buffer.ptr());
+    dispatch_ocall(run_data);
+  });
+
+  uintptr_t encl_ret;
+  enclave.run(&encl_ret);
+
+  return *run_data.report;
+}

--- a/examples/attestation/host/host.h
+++ b/examples/attestation/host/host.h
@@ -1,0 +1,81 @@
+//******************************************************************************
+// Copyright (c) 2018, The Regents of the University of California (Regents).
+// All Rights Reserved. See LICENSE for license details.
+//------------------------------------------------------------------------------
+
+#ifndef _ATTESTATION_HOST_H_
+#define _ATTESTATION_HOST_H_
+
+#include <optional>
+#include <utility>
+
+#include "edge/edge_common.h"
+#include "host/keystone.h"
+#include "verifier/report.h"
+
+class SharedBuffer {
+ public:
+  SharedBuffer(void* buffer, size_t buffer_len)
+      /* For now we assume the call struct is at the front of the shared
+       * buffer. This will have to change to allow nested calls. */
+      : edge_call_((struct edge_call*)buffer),
+        buffer_((uintptr_t)buffer),
+        buffer_len_(buffer_len) {}
+
+  void set_ok();
+  void set_bad_offset();
+  void set_bad_ptr();
+
+  int get_ptr_from_offset(edge_data_offset offset, uintptr_t* ptr);
+  int args_ptr(uintptr_t* ptr, size_t* size);
+  std::optional<std::pair<uintptr_t, size_t>>
+  get_call_args_ptr_or_set_bad_offset();
+  std::optional<char*> get_c_string_or_set_bad_offset();
+  std::optional<unsigned long> get_unsigned_long_or_set_bad_offset();
+  std::optional<Report> get_report_or_set_bad_offset();
+  uintptr_t ptr() { return buffer_; }
+  size_t size() { return buffer_len_; }
+  uintptr_t data_ptr();
+  int validate_ptr(uintptr_t ptr);
+  int get_offset_from_ptr(uintptr_t ptr, edge_data_offset* offset);
+  int setup_ret(void* ptr, size_t size);
+  void setup_ret_or_bad_ptr(unsigned long ret_val);
+  int setup_wrapped_ret(void* ptr, size_t size);
+  void setup_wrapped_ret_or_bad_ptr(const std::string& ret_val);
+
+ private:
+  struct edge_call* const edge_call_;
+  uintptr_t const buffer_;
+  size_t const buffer_len_;
+};
+
+// The Host class mimicks a host interacting with the local enclave
+// and the remote verifier.
+class Host {
+public:
+Host(
+    const Keystone::Params& params, const std::string& eapp_file,
+    const std::string& rt_file)
+    : params_(params), eapp_file_(eapp_file), rt_file_(rt_file) {}
+    // Given a random nonce from the remote verifier, this method leaves
+    // it for the enclave to fetch, and returns the attestation report
+    // from the enclave to the verifier.
+    Report run(const std::string& nonce);
+
+private:
+ struct RunData {
+   SharedBuffer shared_buffer;
+   const std::string& nonce;
+   std::unique_ptr<Report> report;
+ };
+ static void dispatch_ocall(RunData& run_data);
+ static void print_buffer_wrapper(RunData& run_data);
+ static void print_value_wrapper(RunData& run_data);
+ static void copy_report_wrapper(RunData& run_data);
+ static void get_host_string_wrapper(RunData& run_data);
+ const Keystone::Params params_;
+ const std::string eapp_file_;
+ const std::string rt_file_;
+};
+
+#endif /* _ATTESTATION_HOST_H_ */

--- a/examples/attestation/host/host.h
+++ b/examples/attestation/host/host.h
@@ -22,28 +22,31 @@ class SharedBuffer {
         buffer_((uintptr_t)buffer),
         buffer_len_(buffer_len) {}
 
-  void set_ok();
-  void set_bad_offset();
-  void set_bad_ptr();
+  uintptr_t ptr() { return buffer_; }
+  size_t size() { return buffer_len_; }
 
-  int get_ptr_from_offset(edge_data_offset offset, uintptr_t* ptr);
-  int args_ptr(uintptr_t* ptr, size_t* size);
-  std::optional<std::pair<uintptr_t, size_t>>
-  get_call_args_ptr_or_set_bad_offset();
   std::optional<char*> get_c_string_or_set_bad_offset();
   std::optional<unsigned long> get_unsigned_long_or_set_bad_offset();
   std::optional<Report> get_report_or_set_bad_offset();
-  uintptr_t ptr() { return buffer_; }
-  size_t size() { return buffer_len_; }
-  uintptr_t data_ptr();
-  int validate_ptr(uintptr_t ptr);
-  int get_offset_from_ptr(uintptr_t ptr, edge_data_offset* offset);
-  int setup_ret(void* ptr, size_t size);
+
+  void set_ok();
   void setup_ret_or_bad_ptr(unsigned long ret_val);
-  int setup_wrapped_ret(void* ptr, size_t size);
   void setup_wrapped_ret_or_bad_ptr(const std::string& ret_val);
 
  private:
+  uintptr_t data_ptr();
+  int args_ptr(uintptr_t* ptr, size_t* size);
+  int validate_ptr(uintptr_t ptr);
+  int get_offset_from_ptr(uintptr_t ptr, edge_data_offset* offset);
+  int get_ptr_from_offset(edge_data_offset offset, uintptr_t* ptr);
+  std::optional<std::pair<uintptr_t, size_t>>
+  get_call_args_ptr_or_set_bad_offset();
+
+  void set_bad_offset();
+  void set_bad_ptr();
+  int setup_ret(void* ptr, size_t size);
+  int setup_wrapped_ret(void* ptr, size_t size);
+
   struct edge_call* const edge_call_;
   uintptr_t const buffer_;
   size_t const buffer_len_;

--- a/examples/attestation/host/verifier.cpp
+++ b/examples/attestation/host/verifier.cpp
@@ -1,0 +1,129 @@
+//******************************************************************************
+// Copyright (c) 2018, The Regents of the University of California (Regents).
+// All Rights Reserved. See LICENSE for license details.
+//------------------------------------------------------------------------------
+#include "verifier.h"
+
+#include <getopt.h>
+#include <stdlib.h>
+
+#include <cerrno>
+#include <cstdio>
+#include <functional>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+#include "host.h"
+#include "host/hash_util.hpp"
+#include "host/keystone.h"
+#include "verifier/report.h"
+#include "verifier/test_dev_key.h"
+
+void
+Verifier::run() {
+  const std::string nonce = std::to_string(random() % 0x100000000);
+  Host host(params_, eapp_file_, rt_file_);
+  Report report = host.run(nonce);
+  verify_report(report, nonce);
+}
+
+void
+Verifier::verify_report(Report& report, const std::string& nonce) {
+  debug_verify(report, _sanctum_dev_public_key);
+
+  byte expected_enclave_hash[MDSIZE];
+  compute_expected_enclave_hash(expected_enclave_hash);
+
+  byte expected_sm_hash[MDSIZE];
+  compute_expected_sm_hash(expected_sm_hash);
+
+  verify_hashes(
+      report, expected_enclave_hash, expected_sm_hash, _sanctum_dev_public_key);
+
+  verify_data(report, nonce);
+}
+
+void
+Verifier::verify_hashes(
+    Report& report, const byte* expected_enclave_hash,
+    const byte* expected_sm_hash, const byte* dev_public_key) {
+  if (report.verify(expected_enclave_hash, expected_sm_hash, dev_public_key)) {
+    printf("Enclave and SM hashes match with expected.\n");
+  } else {
+    printf(
+        "Either the enclave hash or the SM hash (or both) does not "
+        "match with expeced.\n");
+    report.printPretty();
+  }
+}
+
+void
+Verifier::verify_data(Report& report, const std::string& nonce) {
+  if (report.getDataSize() != nonce.length() + 1) {
+    const char error[] =
+        "The size of the data in the report is not equal to the size of the "
+        "nonce initially sent.";
+    printf(error);
+    report.printPretty();
+    throw std::runtime_error(error);
+  }
+
+  if (0 == strcmp(nonce.c_str(), (char*)report.getDataSection())) {
+    printf("Returned data in the report match with the nonce sent.\n");
+  } else {
+    printf("Returned data in the report do NOT match with the nonce sent.\n");
+  }
+}
+
+void
+Verifier::compute_expected_enclave_hash(byte* expected_enclave_hash) {
+  Keystone::Enclave enclave;
+  Keystone::Params simulated_params = params_;
+  simulated_params.setSimulated(true);
+  // This will cause validate_and_hash_enclave to be called when
+  // isSimulated() == true.
+  enclave.init(eapp_file_.c_str(), rt_file_.c_str(), simulated_params);
+  memcpy(expected_enclave_hash, enclave.getHash(), MDSIZE);
+}
+
+void
+Verifier::compute_expected_sm_hash(byte* expected_sm_hash) {
+  // It is important to make sure the size of the SM buffer we are
+  // measuring is the same as the size of the SM buffer allocated by
+  // the bootloader. See keystone/bootrom/bootloader.c for how it is
+  // computed in the bootloader.
+  const size_t sanctum_sm_size = 0x1ff000;
+  std::vector<byte> sm_content(sanctum_sm_size, 0);
+
+  {
+    // Reading SM content from file.
+    FILE* sm_bin = fopen(sm_bin_file_.c_str(), "rb");
+    if (!sm_bin)
+      throw std::runtime_error(
+          "Error opening sm_bin_file_: " + sm_bin_file_ + ", " +
+          std::strerror(errno));
+    if (fread(sm_content.data(), 1, sm_content.size(), sm_bin) <= 0)
+      throw std::runtime_error(
+          "Error reading sm_bin_file_: " + sm_bin_file_ + ", " +
+          std::strerror(errno));
+    fclose(sm_bin);
+  }
+
+  {
+    // The actual SM hash computation.
+    hash_ctx_t hash_ctx;
+    hash_init(&hash_ctx);
+    hash_extend(&hash_ctx, sm_content.data(), sm_content.size());
+    hash_finalize(expected_sm_hash, &hash_ctx);
+  }
+}
+
+void
+Verifier::debug_verify(Report& report, const byte* dev_public_key) {
+  if (report.checkSignaturesOnly(dev_public_key)) {
+    printf("Attestation report SIGNATURE is valid\n");
+  } else {
+    printf("Attestation report is invalid\n");
+  }
+}

--- a/examples/attestation/host/verifier.h
+++ b/examples/attestation/host/verifier.h
@@ -1,0 +1,63 @@
+//******************************************************************************
+// Copyright (c) 2018, The Regents of the University of California (Regents).
+// All Rights Reserved. See LICENSE for license details.
+//------------------------------------------------------------------------------
+#include <getopt.h>
+#include <stdlib.h>
+
+#include <cerrno>
+#include <cstdio>
+#include <functional>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+#include "common/sha3.h"
+#include "host/keystone.h"
+#include "verifier/report.h"
+#include "verifier/test_dev_key.h"
+
+
+class Verifier {
+ public:
+  Verifier(
+      const Keystone::Params& params, const std::string& eapp_file,
+      const std::string& rt_file, const std::string& sm_bin_file)
+      : params_(params),
+        eapp_file_(eapp_file),
+        rt_file_(rt_file),
+        sm_bin_file_(sm_bin_file) {}
+  // This method generates a random nonce, invokes the run() method
+  // of the Host, and verifies that the returned attestation report
+  // is valid.
+  void run();
+
+ private:
+  // Debug only: verifies just the signature but not the hashes.
+  static void debug_verify(Report& report, const byte* dev_public_key);
+
+  // Verifies that both the enclave hash and the SM hash in the
+  // attestation report matches with the expected onces computed by
+  // the Verifier.
+  static void verify_hashes(
+      Report& report, const byte* expected_enclave_hash,
+      const byte* expected_sm_hash, const byte* dev_public_key);
+
+  // Verifies that the nonce returned in the attestation report is
+  // the same as the one sent.
+  static void verify_data(Report& report, const std::string& nonce);
+
+  // Verifies the hashes and the nonce in the attestation report.
+  void verify_report(Report& report, const std::string& nonce);
+
+  // Computes the hash of the expected EApp running in the enclave.
+  void compute_expected_enclave_hash(byte* expected_enclave_hash);
+
+  // Computes the hash of the expected Security Monitor (SM).
+  void compute_expected_sm_hash(byte* expected_sm_hash);
+
+  const Keystone::Params params_;
+  const std::string eapp_file_;
+  const std::string rt_file_;
+  const std::string sm_bin_file_;
+};

--- a/include/common/sha3.h
+++ b/include/common/sha3.h
@@ -1,6 +1,7 @@
 // sha3.h
 // 19-Nov-11  Markku-Juhani O. Saarinen <mjos@iki.fi>
-#pragma once
+#ifndef __SHA3_H_
+#define __SHA3_H_
 
 #include <stddef.h>
 #include <stdint.h>
@@ -39,3 +40,5 @@ sha3_final(void* md, sha3_ctx_t* c);  // digest goes to md
 // compute a sha3 hash (md) of given byte length from "in"
 void*
 sha3(const void* in, size_t inlen, void* md, int mdlen);
+
+#endif /* __SHA3_H_ */

--- a/include/edge/edge_call.h
+++ b/include/edge/edge_call.h
@@ -3,7 +3,7 @@
 // All Rights Reserved. See LICENSE for license details.
 //------------------------------------------------------------------------------
 #ifndef __EDGE_CALL_H_
-#define __EDGE_CALL_H__
+#define __EDGE_CALL_H_
 
 #include "edge_common.h"
 

--- a/include/edge/edge_common.h
+++ b/include/edge/edge_common.h
@@ -2,8 +2,8 @@
 // Copyright (c) 2018, The Regents of the University of California (Regents).
 // All Rights Reserved. See LICENSE for license details.
 //------------------------------------------------------------------------------
-#ifndef _EDGE_COMMON_H_
-#define _EDGE_COMMON_H_
+#ifndef __EDGE_COMMON_H_
+#define __EDGE_COMMON_H_
 #include <stddef.h>
 #include <stdint.h>
 

--- a/include/edge/edge_syscall.h
+++ b/include/edge/edge_syscall.h
@@ -60,16 +60,16 @@ typedef struct sargs_SYS_epoll_create1 {
 typedef struct sargs_SYS_socket{
   int domain;
   int type;
-  int protocol; 
-} sargs_SYS_socket; 
+  int protocol;
+} sargs_SYS_socket;
 
 typedef struct sargs_SYS_setsockopt{
   int socket;
   int level;
   int option_name;
-  int option_value; 
+  int option_value;
   socklen_t option_len;
-} sargs_SYS_setsockopt; 
+} sargs_SYS_setsockopt;
 
 typedef struct sargs_SYS_bind{
   int sockfd;
@@ -89,40 +89,40 @@ typedef struct sargs_SYS_accept{
 } sargs_SYS_accept;
 
 typedef struct sargs_SYS_epoll_ctl{
-  int epfd; 
+  int epfd;
   int op;
-  int fd; 
-  uintptr_t event; 
+  int fd;
+  uintptr_t event;
 } sargs_SYS_epoll_ctl;
 
 typedef struct sargs_SYS_fcntl {
-  int fd; 
-  int cmd; 
-  int has_struct; 
-  unsigned long arg[]; 
+  int fd;
+  int cmd;
+  int has_struct;
+  unsigned long arg[];
 } sargs_SYS_fcntl;
 
 typedef struct sargs_SYS_getcwd {
   size_t size;
-  char buf[]; 
+  char buf[];
 } sargs_SYS_getcwd;
 
 typedef struct sargs_SYS_chdir{
-  char path[0]; 
+  char path[0];
 } sargs_SYS_chdir;
 
 
 typedef struct sargs_SYS_epoll_pwait{
-  int epfd; 
+  int epfd;
   struct epoll_event events;
   int maxevents;
-  int timeout; 
+  int timeout;
 } sargs_SYS_epoll_pwait;
 
 
 typedef struct sargs_SYS_getpeername{
   int sockfd;
-  struct sockaddr_storage addr;  
+  struct sockaddr_storage addr;
   socklen_t addrlen;
 } sargs_SYS_getpeername;
 
@@ -131,7 +131,7 @@ typedef struct sargs_SYS_getpeername{
 typedef struct sargs_SYS_renameat2{
   int olddirfd;
   char oldpath[128];
-  int newdirfd; 
+  int newdirfd;
   char newpath[128];
   unsigned int flags;
 } sargs_SYS_renameat2;

--- a/include/edge/syscall_nums.h
+++ b/include/edge/syscall_nums.h
@@ -1,5 +1,8 @@
 // Copied from musl's build (build/obj/include/bits/syscall.h)
 // In the future we'll want to build musl with our own syscalls as the targets
+#ifndef __SYSCALL_NUMS_H_
+#define __SYSCALL_NUMS_H_
+
 #define __NR_io_setup 0
 #define __NR_io_destroy 1
 #define __NR_io_submit 2
@@ -555,3 +558,5 @@
 #define SYS_pkey_free 290
 #define SYS_sysriscv __NR_arch_specific_syscall
 #define SYS_riscv_flush_icache (__NR_sysriscv + 15)
+
+#endif /* __SYSCALL_NUMS_H_ */

--- a/include/host/Enclave.hpp
+++ b/include/host/Enclave.hpp
@@ -10,9 +10,12 @@
 #include <stddef.h>
 #include <sys/types.h>
 #include <unistd.h>
+
 #include <cerrno>
 #include <cstring>
+#include <functional>
 #include <iostream>
+
 #include "./common.h"
 extern "C" {
 #include "common/sha3.h"
@@ -25,8 +28,7 @@ extern "C" {
 
 namespace Keystone {
 
-class Enclave;
-typedef void (*OcallFunc)(void*);
+typedef std::function<void(void*)> OcallFunc;
 
 class Enclave {
  private:

--- a/include/host/hash_util.hpp
+++ b/include/host/hash_util.hpp
@@ -18,5 +18,7 @@ void
 hash_extend_page(hash_ctx_t* hash_ctx, const void* ptr);
 void
 hash_finalize(void* md, hash_ctx_t* hash_ctx);
+/*
 void
 printHash(char* hash);
+*/

--- a/include/host/hash_util.hpp
+++ b/include/host/hash_util.hpp
@@ -18,7 +18,3 @@ void
 hash_extend_page(hash_ctx_t* hash_ctx, const void* ptr);
 void
 hash_finalize(void* md, hash_ctx_t* hash_ctx);
-/*
-void
-printHash(char* hash);
-*/

--- a/include/verifier/Report.hpp
+++ b/include/verifier/Report.hpp
@@ -49,4 +49,5 @@ class Report {
   void* getDataSection();
   size_t getDataSize();
   byte* getEnclaveHash();
+  byte* getSmHash();
 };

--- a/include/verifier/test_dev_key.h
+++ b/include/verifier/test_dev_key.h
@@ -1,3 +1,6 @@
+#ifndef _TEST_DEV_KEY_H_
+#define _TEST_DEV_KEY_H_
+
 /* These are known device TESTING keys, use them for testing on platforms/qemu
  */
 
@@ -16,3 +19,5 @@ static const unsigned char _sanctum_dev_public_key[] = {
     0x96, 0x6f, 0x7c, 0x1f, 0xf3, 0x25, 0x64, 0xdd, 0x17, 0xd7, 0xdc,
     0x2b, 0x46, 0xcb, 0x50, 0xa8, 0x4a, 0x69, 0x27, 0x0b, 0x4c};
 static const size_t _sanctum_dev_public_key_len = 32;
+
+#endif /* _TEST_DEV_KEY_H_ */

--- a/src/host/hash_util.cpp
+++ b/src/host/hash_util.cpp
@@ -1,4 +1,3 @@
-
 //******************************************************************************
 // Copyright (c) 2020, The Regents of the University of California (Regents).
 // All Rights Reserved. See LICENSE for license details.
@@ -28,11 +27,3 @@ void
 hash_finalize(void* md, hash_ctx_t* hash_ctx) {
   sha3_final(md, hash_ctx);
 }
-/*
-void
-printHash(char* hash) {
-  for (int i = 0; i < MDSIZE; i += sizeof(uintptr_t)) {
-    printf("%.16lx ", *((uintptr_t*)((uintptr_t)hash + i)));
-  }
-  printf("\n");
-}*/

--- a/src/verifier/Report.cpp
+++ b/src/verifier/Report.cpp
@@ -123,7 +123,12 @@ Report::printPretty() {
 
 byte*
 Report::getEnclaveHash() {
-  return report.enclave.hash;
+    return report.enclave.hash;
+}
+
+byte*
+Report::getSmHash() {
+    return report.sm.hash;
 }
 
 int


### PR DESCRIPTION
This commit implements a full attestation example, where the attestor runs in the enclave and sends to the host an attestation report with a nonce given by the remote verifier. The remote verifier generates the random nonce in the beginning and verifies the report in the end.